### PR TITLE
fix(ale): ensure refreshOnInsertMode is respected for Ale

### DIFF
--- a/src/diagnostic/manager.ts
+++ b/src/diagnostic/manager.ts
@@ -644,8 +644,8 @@ export class DiagnosticManager implements Disposable {
     let buf = Array.from(this.buffers.values()).find(o => o.uri == uri)
     if (!buf) return false
     let { displayByAle, refreshOnInsertMode } = this.config
+    if (!refreshOnInsertMode && workspace.insertMode) return false
     if (!displayByAle) {
-      if (!refreshOnInsertMode && workspace.insertMode) return false
       let diagnostics = this.getDiagnostics(uri)
       if (this.enabled) {
         if (force) {


### PR DESCRIPTION
The refreshOnInsertMode configuration flag was not being respected in case diagnostics were being set to the Ale plugin.

Apparently, this is a regression as this problem has been fixed in a previous PR: https://github.com/neoclide/coc.nvim/pull/1236/files